### PR TITLE
feat(pt): add atomic_weight parameter to dipole model

### DIFF
--- a/deepmd/dpmodel/atomic_model/base_atomic_model.py
+++ b/deepmd/dpmodel/atomic_model/base_atomic_model.py
@@ -226,6 +226,14 @@ class BaseAtomicModel(BaseAtomicModel_, NativeOP):
             ret_dict[kk] = xp.reshape(tmp_arr, out_shape)
             if atomic_weight is not None:
                 _out_shape = ret_dict[kk].shape
+                # Validate that atomic_weight.shape[2] matches the flattened trailing dimensions
+                # of the output to ensure correct broadcasting behavior
+                out_shape2 = math.prod(_out_shape[2:])
+                if atomic_weight.shape[2] != out_shape2:
+                    raise ValueError(
+                        f"atomic_weight shape {atomic_weight.shape} incompatible with output shape {_out_shape}. "
+                        f"Expected atomic_weight.shape[2] to be {out_shape2} for key '{kk}'"
+                    )
                 ret_dict[kk] = ret_dict[kk] * atomic_weight.reshape(
                     [_out_shape[0], _out_shape[1], -1]
                 )

--- a/deepmd/dpmodel/model/make_model.py
+++ b/deepmd/dpmodel/model/make_model.py
@@ -68,7 +68,7 @@ def model_call_from_call_lower(
     fparam: Array | None = None,
     aparam: Array | None = None,
     do_atomic_virial: bool = False,
-    atomic_weight: Optional[np.ndarray] = None,
+    atomic_weight: Array | None = None,
 ) -> dict[str, Array]:
     """Return model prediction from lower interface.
 
@@ -231,7 +231,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
             fparam: Array | None = None,
             aparam: Array | None = None,
             do_atomic_virial: bool = False,
-            atomic_weight: Optional[np.ndarray] = None,
+            atomic_weight: Array | None = None,
         ) -> dict[str, Array]:
             """Return model prediction.
 
@@ -292,7 +292,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
             fparam: Array | None = None,
             aparam: Array | None = None,
             do_atomic_virial: bool = False,
-            atomic_weight: Optional[np.ndarray] = None,
+            atomic_weight: Array | None = None,
         ) -> dict[str, Array]:
             """Return model prediction. Lower interface that takes
             extended atomic coordinates and types, nlist, and mapping
@@ -359,7 +359,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
             fparam: Array | None = None,
             aparam: Array | None = None,
             do_atomic_virial: bool = False,
-            atomic_weight: Optional[np.ndarray] = None,
+            atomic_weight: Array | None = None,
         ) -> dict[str, Array]:
             atomic_ret = self.atomic_model.forward_common_atomic(
                 extended_coord,
@@ -387,7 +387,9 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
             fparam: Array | None = None,
             aparam: Array | None = None,
             atomic_weight: Array | None = None,
-        ) -> tuple[Array, Array, np.ndarray | None, np.ndarray | None, np.ndarray | None, str]:
+        ) -> tuple[
+            Array, Array, np.ndarray | None, np.ndarray | None, np.ndarray | None, str
+        ]:
             """Cast the input data to global float type."""
             input_prec = RESERVED_PRECISION_DICT[self.precision_dict[coord.dtype.name]]
             ###

--- a/deepmd/pt/infer/deep_eval.py
+++ b/deepmd/pt/infer/deep_eval.py
@@ -543,16 +543,25 @@ class DeepEval(DeepEvalBackend):
                 atomic_weight = np.tile(atomic_weight, (nframes, 1))
             elif atomic_weight.ndim == 2:
                 # (nframes, natoms) or (natoms, k)
-                if atomic_weight.shape[0] == natoms and atomic_weight.shape[1] != nframes:
+                if (
+                    atomic_weight.shape[0] == natoms
+                    and atomic_weight.shape[1] != nframes
+                ):
                     # (natoms, k) - broadcast across frames
                     atomic_weight = np.tile(atomic_weight, (nframes, 1, 1))
-                elif atomic_weight.shape[0] != nframes or atomic_weight.shape[1] != natoms:
+                elif (
+                    atomic_weight.shape[0] != nframes
+                    or atomic_weight.shape[1] != natoms
+                ):
                     raise ValueError(
                         f"atomic_weight shape {atomic_weight.shape} incompatible with nframes={nframes} and natoms={natoms}"
                     )
             elif atomic_weight.ndim == 3:
                 # (nframes, natoms, k)
-                if atomic_weight.shape[0] != nframes or atomic_weight.shape[1] != natoms:
+                if (
+                    atomic_weight.shape[0] != nframes
+                    or atomic_weight.shape[1] != natoms
+                ):
                     raise ValueError(
                         f"atomic_weight shape {atomic_weight.shape} incompatible with nframes={nframes} and natoms={natoms}"
                     )
@@ -560,7 +569,7 @@ class DeepEval(DeepEvalBackend):
                 raise ValueError(
                     f"atomic_weight must have 1, 2, or 3 dimensions, got {atomic_weight.ndim}"
                 )
-            
+
             atomic_weight_input = to_torch_tensor(
                 atomic_weight.reshape(nframes, natoms, -1)
             )
@@ -657,16 +666,25 @@ class DeepEval(DeepEvalBackend):
                 atomic_weight = np.tile(atomic_weight, (nframes, 1))
             elif atomic_weight.ndim == 2:
                 # (nframes, natoms) or (natoms, k)
-                if atomic_weight.shape[0] == natoms and atomic_weight.shape[1] != nframes:
+                if (
+                    atomic_weight.shape[0] == natoms
+                    and atomic_weight.shape[1] != nframes
+                ):
                     # (natoms, k) - broadcast across frames
                     atomic_weight = np.tile(atomic_weight, (nframes, 1, 1))
-                elif atomic_weight.shape[0] != nframes or atomic_weight.shape[1] != natoms:
+                elif (
+                    atomic_weight.shape[0] != nframes
+                    or atomic_weight.shape[1] != natoms
+                ):
                     raise ValueError(
                         f"atomic_weight shape {atomic_weight.shape} incompatible with nframes={nframes} and natoms={natoms}"
                     )
             elif atomic_weight.ndim == 3:
                 # (nframes, natoms, k)
-                if atomic_weight.shape[0] != nframes or atomic_weight.shape[1] != natoms:
+                if (
+                    atomic_weight.shape[0] != nframes
+                    or atomic_weight.shape[1] != natoms
+                ):
                     raise ValueError(
                         f"atomic_weight shape {atomic_weight.shape} incompatible with nframes={nframes} and natoms={natoms}"
                     )
@@ -674,7 +692,7 @@ class DeepEval(DeepEvalBackend):
                 raise ValueError(
                     f"atomic_weight must have 1, 2, or 3 dimensions, got {atomic_weight.ndim}"
                 )
-            
+
             atomic_weight_input = to_torch_tensor(
                 atomic_weight.reshape(nframes, natoms, -1)
             )

--- a/deepmd/pt/model/model/dipole_model.py
+++ b/deepmd/pt/model/model/dipole_model.py
@@ -60,6 +60,7 @@ class DipoleModel(DPModelCommon, DPDipoleModel_):
         fparam: torch.Tensor | None = None,
         aparam: torch.Tensor | None = None,
         do_atomic_virial: bool = False,
+        atomic_weight: Optional[torch.Tensor] = None,
     ) -> dict[str, torch.Tensor]:
         model_ret = self.forward_common(
             coord,
@@ -68,6 +69,7 @@ class DipoleModel(DPModelCommon, DPDipoleModel_):
             fparam=fparam,
             aparam=aparam,
             do_atomic_virial=do_atomic_virial,
+            atomic_weight=atomic_weight,
         )
         if self.get_fitting_net() is not None:
             model_predict = {}
@@ -98,6 +100,7 @@ class DipoleModel(DPModelCommon, DPDipoleModel_):
         fparam: torch.Tensor | None = None,
         aparam: torch.Tensor | None = None,
         do_atomic_virial: bool = False,
+        atomic_weight: torch.Tensor | None = None,
         comm_dict: dict[str, torch.Tensor] | None = None,
     ) -> dict[str, torch.Tensor]:
         model_ret = self.forward_common_lower(
@@ -110,6 +113,7 @@ class DipoleModel(DPModelCommon, DPDipoleModel_):
             do_atomic_virial=do_atomic_virial,
             comm_dict=comm_dict,
             extra_nlist_sort=self.need_sorted_nlist_for_lower(),
+            atomic_weight=atomic_weight,
         )
         if self.get_fitting_net() is not None:
             model_predict = {}

--- a/deepmd/pt/model/model/dipole_model.py
+++ b/deepmd/pt/model/model/dipole_model.py
@@ -60,7 +60,7 @@ class DipoleModel(DPModelCommon, DPDipoleModel_):
         fparam: torch.Tensor | None = None,
         aparam: torch.Tensor | None = None,
         do_atomic_virial: bool = False,
-        atomic_weight: Optional[torch.Tensor] = None,
+        atomic_weight: torch.Tensor | None = None,
     ) -> dict[str, torch.Tensor]:
         model_ret = self.forward_common(
             coord,

--- a/deepmd/pt/model/model/make_model.py
+++ b/deepmd/pt/model/model/make_model.py
@@ -138,7 +138,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
             fparam: torch.Tensor | None = None,
             aparam: torch.Tensor | None = None,
             do_atomic_virial: bool = False,
-            atomic_weight: Optional[torch.Tensor] = None,
+            atomic_weight: torch.Tensor | None = None,
         ) -> dict[str, torch.Tensor]:
             """Return model prediction.
 
@@ -255,7 +255,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
             do_atomic_virial: bool = False,
             comm_dict: dict[str, torch.Tensor] | None = None,
             extra_nlist_sort: bool = False,
-            atomic_weight: Optional[torch.Tensor] = None,
+            atomic_weight: torch.Tensor | None = None,
         ) -> dict[str, torch.Tensor]:
             """Return model prediction. Lower interface that takes
             extended atomic coordinates and types, nlist, and mapping
@@ -642,7 +642,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
             fparam: torch.Tensor | None = None,
             aparam: torch.Tensor | None = None,
             do_atomic_virial: bool = False,
-            atomic_weight: Optional[torch.Tensor] = None,
+            atomic_weight: torch.Tensor | None = None,
         ) -> dict[str, torch.Tensor]:
             # directly call the forward_common method when no specific transform rule
             return self.forward_common(

--- a/deepmd/pt/model/model/make_model.py
+++ b/deepmd/pt/model/model/make_model.py
@@ -138,6 +138,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
             fparam: torch.Tensor | None = None,
             aparam: torch.Tensor | None = None,
             do_atomic_virial: bool = False,
+            atomic_weight: Optional[torch.Tensor] = None,
         ) -> dict[str, torch.Tensor]:
             """Return model prediction.
 
@@ -191,6 +192,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
                 do_atomic_virial=do_atomic_virial,
                 fparam=fp,
                 aparam=ap,
+                atomic_weight=atomic_weight,
             )
             model_predict = communicate_extended_output(
                 model_predict_lower,
@@ -247,6 +249,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
             do_atomic_virial: bool = False,
             comm_dict: dict[str, torch.Tensor] | None = None,
             extra_nlist_sort: bool = False,
+            atomic_weight: Optional[torch.Tensor] = None,
         ) -> dict[str, torch.Tensor]:
             """Return model prediction. Lower interface that takes
             extended atomic coordinates and types, nlist, and mapping
@@ -297,6 +300,7 @@ def make_model(T_AtomicModel: type[BaseAtomicModel]) -> type:
                 fparam=fp,
                 aparam=ap,
                 comm_dict=comm_dict,
+                atomic_weight=atomic_weight,
             )
             model_predict = fit_output_to_model_output(
                 atomic_ret,

--- a/deepmd/pt/train/wrapper.py
+++ b/deepmd/pt/train/wrapper.py
@@ -162,6 +162,7 @@ class ModelWrapper(torch.nn.Module):
         do_atomic_virial: bool = False,
         fparam: torch.Tensor | None = None,
         aparam: torch.Tensor | None = None,
+        atomic_weight: torch.Tensor | None = None,
     ) -> tuple[Any, Any, Any]:
         if not self.multi_task:
             task_key = "Default"
@@ -176,6 +177,7 @@ class ModelWrapper(torch.nn.Module):
             "do_atomic_virial": do_atomic_virial,
             "fparam": fparam,
             "aparam": aparam,
+            "atomic_weight": atomic_weight,
         }
         has_spin = getattr(self.model[task_key], "has_spin", False)
         if callable(has_spin):

--- a/deepmd/pt/train/wrapper.py
+++ b/deepmd/pt/train/wrapper.py
@@ -189,6 +189,8 @@ class ModelWrapper(torch.nn.Module):
             model_pred = self.model[task_key](**input_dict)
             return model_pred, None, None
         else:
+            # remove atomic_weight in loss
+            input_dict.pop("atomic_weight", None)
             natoms = atype.shape[-1]
             model_pred, loss, more_loss = self.loss[task_key](
                 input_dict,

--- a/source/tests/pt/model/test_dp_atomic_model.py
+++ b/source/tests/pt/model/test_dp_atomic_model.py
@@ -73,6 +73,13 @@ class TestDPAtomicModel(unittest.TestCase, TestCaseSingleFrameWithNlist):
                 to_numpy_array(ret0["energy"]),
                 to_numpy_array(ret1["energy"]),
             )
+            # add test for atomic_weight
+            aw = torch.rand([nf, nloc, 1], dtype=dtype, device=env.DEVICE)
+            ret2 = md0.forward_common_atomic(*args, atomic_weight=aw)
+            np.testing.assert_allclose(
+                to_numpy_array(ret0["energy"] * aw.reshape(nf, nloc, -1)),
+                to_numpy_array(ret2["energy"]),
+            )
 
     def test_dp_consistency(self) -> None:
         nf, nloc, nnei = self.nlist.shape
@@ -100,6 +107,14 @@ class TestDPAtomicModel(unittest.TestCase, TestCaseSingleFrameWithNlist):
         np.testing.assert_allclose(
             ret0["energy"],
             to_numpy_array(ret1["energy"]),
+        )
+        # add test for atomic_weight
+        aw = torch.rand([nf, nloc, 1], dtype=dtype, device=env.DEVICE)
+        ret2 = md0.forward_common_atomic(*args0, atomic_weight=to_numpy_array(aw))
+        ret3 = md1.forward_common_atomic(*args1, atomic_weight=aw)
+        np.testing.assert_allclose(
+            ret2["energy"],
+            to_numpy_array(ret3["energy"]),
         )
 
     def test_jit(self) -> None:


### PR DESCRIPTION
- Add atomic_weight parameter to BaseAtomicModel.forward_common_atomic() to support scaling outputs with atomic weights
- Update model interfaces in dpmodel and pt modules to pass atomic_weight parameter
- Add tests for atomic_weight functionality in dipole model
- This enables weighted dipole calculations where atomic contributions can be scaled differently

This change is part of the dipole_with_atomic_weight feature branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-atom "atomic_weight" input available across models, inference/eval, and training; when supplied, per-atom outputs are scaled by these weights with broadcasting and shape validation.

* **Tests**
  * Added tests ensuring atomic-weight propagation, correct scaling of atomic outputs, and consistency across model paths.

* **Chores**
  * Threaded atomic_weight through public APIs, eval, and training call paths; updated docstrings and input handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->